### PR TITLE
Parse requirements properly with pip

### DIFF
--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -26,6 +26,9 @@ from virtualenv import (  # noqa
     create_bootstrap_script,
 )
 
+from pip.commands.install import InstallCommand
+from pip.req import parse_requirements
+
 logger = getLogger(__name__)
 
 # http://www.astro.keele.ac.uk/oldusers/rno/Computing/File_magic.html
@@ -87,15 +90,17 @@ class Terrarium(object):
     def requirements(self):
         if self._requirements is not None:
             return self._requirements
-        lines = []
+        requirements_set = set()
+
+        # need options object for parse_requirements
+        command = InstallCommand()
+        options, _ = command.parser.parse_args([])
+
         for arg in self.args.reqs:
             if os.path.exists(arg):
-                with open(arg, 'r') as f:
-                    for line in f.readlines():
-                        line = line.strip()
-                        if line and not line.startswith('#'):
-                            lines.append(line)
-        self._requirements = sorted(lines)
+                reqs = parse_requirements(arg, options=options)
+                requirements_set.update([str(r.req) for r in reqs])
+        self._requirements = sorted(list(requirements_set))
         return self._requirements
 
     def install(self):

--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -29,6 +29,10 @@ from virtualenv import (  # noqa
 from pip.commands.install import InstallCommand
 from pip.req import parse_requirements
 
+import pip
+if hasattr(pip, 'version_control'):
+    pip.version_control()
+
 logger = getLogger(__name__)
 
 # http://www.astro.keele.ac.uk/oldusers/rno/Computing/File_magic.html

--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -99,8 +99,8 @@ class Terrarium(object):
         for arg in self.args.reqs:
             if os.path.exists(arg):
                 reqs = parse_requirements(arg, options=options)
-                requirements_set.update([str(r.req) for r in reqs])
-        self._requirements = sorted(list(requirements_set))
+                requirements_set.update([r.url or r.req for r in reqs])
+        self._requirements = sorted([str(r) for r in requirements_set])
         return self._requirements
 
     def install(self):


### PR DESCRIPTION
To support requirements formats like "-r" in requirements files, I replace the current parsing with pip's `parse_requirements`.

This will change existing terrarium keys.
