### PR TITLE
Respect S3 policy of access key and fail gracefully

### DIFF
--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -319,7 +319,7 @@ class Terrarium(object):
                 self.args.s3_bucket,
                 policy='public-read',
             )
-        except boto.exception.S3CreateError:
+        except (boto.exception.S3CreateError, boto.exception.S3ResponseError):
             pass
         return boto.s3.bucket.Bucket(conn, name=self.args.s3_bucket)
 


### PR DESCRIPTION
If the user is not allowed to create buckets, catch exception and move on.

When your user has a very specific policy attached that only allows necessary operations.
