### PR TITLE
Add a require download flag

### DIFF
--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -154,6 +154,13 @@ class Terrarium(object):
             downloaded = self.download(new_target)
 
         if not downloaded:
+            if self.args.require_download:
+                logger.error(
+                    'Failed to download bundle and download is '
+                    'required. Refusing to build a new bundle.'
+                )
+                return 1
+
             # Create a self-contained script to create a virtual environment
             # and install all of the requested requirements
             logger.info('Building new environment')
@@ -589,6 +596,15 @@ def parse_args():
             attempt to download an existing terrarium bundle instead of
             building a new one. Using --no-download forces terrarium to build a
             new environment.
+        ''',
+    )
+    ap.add_argument(
+        '--require-download',
+        default=False,
+        action='store_true',
+        help='''
+            If we fail to download a terrarium bundle from the storage
+            location, do not proceed to build one.
         ''',
     )
     ap.add_argument(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -533,3 +533,19 @@ class TestTerrarium(TerrariumTester):
         self.assertTrue(
             'do_not_show_me' not in output[1]
         )
+
+    def test_require_download(self):
+        self._add_test_requirement()
+
+        output = self.assertInstall(
+            return_code=1,
+            storage_dir=self.storage_dir,
+            require_download=True,
+        )
+        self.assertEqual(
+            output[1],
+            'Download archive failed\n'
+            'Failed to download bundle and download is required. '
+            'Refusing to build a new bundle.\n',
+        )
+        self.assertNotExists(self.python)


### PR DESCRIPTION
Make it required to pass in the location of a pre-compiled version of the requirements. Fail if there is nothing there.
