### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,16 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, pypy
+envlist = py25, py26, py27, pypy
 
 [testenv]
 commands = nosetests {posargs:-v}
 deps =
     ipdb
+    nose
+
+[testenv:py25]
+setenv =
+    PIP_INSECURE = 1
+deps =
     nose


### PR DESCRIPTION
This adds support for testing with [tox](http://tox.testrun.org/).

Sample run:

```
marca@marca-mac:~/dev/git-repos/terrarium$ tox
...
  py25: commands succeeded
  py26: commands succeeded
  py27: commands succeeded
ERROR:   pypy: commands failed
```

Note: I know that you have [Travis CI](http://travis-ci.org/) set up which I also love. I think it's handy to have both Travis CI and tox set up -- the reason is that tox lets developers test their changes locally across multiple Pythons **without having to check in or push their changes**. Thus, I find Tox super handy for working on Python 3 compatibility, because you can keep iterating on making changes and testing with Tox.

As for the pypy failure, there only seems to be one test failure, so I thought it might be easy to fix. I filed it as issue #39. 

Note that you can run a single test more quickly like this:

```
tox -e pypy -- tests.tests:TestTerrarium.test_install_storage_dir_archive_extracted
```
