### PR TITLE
shlex comments=True breaks remote source requirements

### DIFF
--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -498,11 +498,11 @@ class Terrarium(object):
 
     def create_bootstrap(self, dest):
         extra_text = (
-            TERRARIUM_BOOTSTRAP_EXTRA_TEXT % {
-                'REQUIREMENTS': self.requirements,
-                'VENV_LOGGING': self.args.virtualenv_log_level,
-                'PIP_LOGGING': self.args.pip_log_level,
-            }
+            TERRARIUM_BOOTSTRAP_EXTRA_TEXT.format(
+                requirements=self.requirements,
+                virtualenv_log_level=self.args.virtualenv_log_level,
+                pip_log_level=self.args.pip_log_level,
+            )
         )
         output = create_bootstrap_script(extra_text)
         with open(dest, 'w') as f:
@@ -514,11 +514,11 @@ def adjust_options(options, args):
     options.use_distribute = True
     options.system_site_packages = False
 
-REQUIREMENTS = %(REQUIREMENTS)s
+REQUIREMENTS = {requirements}
 
 def after_install(options, base):
     # Debug logging for virtualenv
-    logger.consumers = [(%(VENV_LOGGING)s, sys.stdout)]
+    logger.consumers = [({virtualenv_log_level}, sys.stdout)]
 
     home_dir, lib_dir, inc_dir, bin_dir = path_locations(base)
 
@@ -528,8 +528,11 @@ def after_install(options, base):
     sys.executable = join(os.path.abspath(bin_dir), 'python')
 
     # Create a symlink for pythonM.N
-    pyversion = (sys.version_info[0], sys.version_info[1])
-    pyversion_path = join(bin_dir, 'python%%d.%%d' %% pyversion)
+    pyv_major, pyv_minor = (sys.version_info[0], sys.version_info[1])
+    pyversion_path = join(bin_dir, 'python{{major}}.{{minor}}'.format(
+        major=pyv_major,
+        minor=pyv_minor,
+    ))
     # If virtualenv is run using pythonM.N, that binary will already exist so
     # there's no need to create it
     if not os.path.exists(pyversion_path):
@@ -544,7 +547,7 @@ def after_install(options, base):
     import shlex
 
     # Debug logging for pip
-    pip.logger.consumers = [(%(PIP_LOGGING)s, sys.stdout)]
+    pip.logger.consumers = [({virtualenv_log_level}, sys.stdout)]
 
     # If we are on a version of pip before 1.2, load version control modules
     # for installing 'editables'

--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -572,6 +572,8 @@ def after_install(options, base):
     options.ignore_installed = True
     requirementSet = c.run(options, args)
 
+    os.unlink(file_path)
+
     make_environment_relocatable(base)
 '''
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -268,6 +268,20 @@ class TestTerrarium(TerrariumTester):
         expected = ['test_requirement']
         self.assertEqual(actual, expected)
 
+    def test_install_editable_with_hash_egg_name(self):
+        # Verify that a requirement file with a hash egg name can be used and
+        # is not confused with a comment
+        # If the #egg=foobar is removed, pip will fail
+        self._add_requirements(
+            '-e git+git://github.com/PolicyStat/terrarium.git#egg=foobar',
+        )
+        self.assertInstall()
+        actual = self._can_import_requirements(
+            'terrarium',
+        )
+        expected = ['terrarium']
+        self.assertEqual(actual, expected)
+
     def test_hash_default_empty_requirements(self):
         # Verify that the hash of an empty requirements file is predictable
         command = 'hash %s' % (


### PR DESCRIPTION
External requirements need `#egg=Package` at the end of the URI. This gets striped off because of `comments=True`.