### PR TITLE
Fix for #51 (upgrade virtualenv)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def find_version(*file_paths):
 def main():
     python_version = sys.version_info[:2]
     install_requires = [
-        'virtualenv>=1.7.2,<=1.9.1',
+        'virtualenv>=12.0,<13.0',
     ]
     if python_version < (2, 7) or (3, 0) <= python_version <= (3, 1):
         install_requires += ['argparse']


### PR DESCRIPTION
nosetests pass, then tox tests passed

```
  docs: commands succeeded
  pep8: commands succeeded
  py26-venv-1.7.2: commands succeeded
  py26-venv-1.8.4: commands succeeded
  py26-venv-1.9.1: commands succeeded
  py27-venv-1.7.2: commands succeeded
  py27-venv-1.8.4: commands succeeded
  py27-venv-1.9.1: commands succeeded
  congratulations :)
```
