### PR TITLE
Add an additional test to check inter-dependencies.

### DIFF
--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -133,7 +133,7 @@ class Terrarium(object):
                         line = line.strip()
                         if line and not line.startswith('#'):
                             lines.append(line)
-        self._requirements = sorted(lines)
+        self._requirements = lines
         return self._requirements
 
     def restore_previously_backed_up_environment(self):

--- a/tests/fixtures/foo_requirement/setup.py
+++ b/tests/fixtures/foo_requirement/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+setup_options = dict(
+    name='foo_requirement',
+    version='0.1.0dev',
+    author='Kyle Gibson',
+    author_email='kyle.gibson@frozenonline.com',
+    description='Another test requirement fixture',
+    license='BSD',
+    url='',
+    packages=['foo_requirement'],
+    long_description='',
+    install_requires=['test_requirement'],
+    classifiers=[],
+    zip_safe=False,
+)
+
+setup(**setup_options)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -257,6 +257,25 @@ class TestTerrarium(TerrariumTester):
         expected = ['test_requirement']
         self.assertEqual(actual, expected)
 
+    def test_install_requirements_with_dependency(self):
+        """ This test involves a requirements file with two items,
+            test_requirement and foo_requirement. foo_requirement
+            has test_requirement as a dependency. We check that,
+            if test_requirement comes first in the requirements,
+            the install of foo_requirement will be successful.
+        """
+        self._add_requirements(
+            self._get_path('fixtures', 'test_requirement'),
+            self._get_path('fixtures', 'foo_requirement'),
+        )
+        self.assertInstall()
+        actual = self._can_import_requirements(
+            'test_requirement',
+            'foo_requirement',
+        )
+        expected = ['test_requirement', 'foo_requirement']
+        self.assertEqual(actual, expected)
+
     def test_install_with_requirement_comments(self):
         # Verify that a requirement file with comment lines can be used.
         self._add_requirements(


### PR DESCRIPTION
The reason for this test is the following. If `foo_requirement` depends only on `test_requirement`, and both are explicitly installed from files after being mentioned from the same `requirements.txt`, then pip will not look for `test_requirement` when installing `foo_requirement` - it will be clever enough to realize that it's just been installed. But terrarium will complain that it can't find the dependency.

Note that this behavior of `pip` depends on the two packages appearing in the right order in the `requirements.txt` file. Doing things this way might be a misuse of undocumented pip behavior, I have no idea. In any case, it is something which pip users might depend on.
