### PR TITLE
Support latest 2 versions of virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 language: python
-install: pip install tox-travis
-script: tox
+env:
+  - TOX_ENV=docs
+  - TOX_ENV=py27-flake8
+  - TOX_ENV=py26-virtualenv-17x
+  - TOX_ENV=py26-virtualenv-18x
+  - TOX_ENV=py26-virtualenv-19x
+  - TOX_ENV=py26-virtualenv-150x
+  - TOX_ENV=py26-virtualenv-151x
+  - TOX_ENV=py27-virtualenv-17x
+  - TOX_ENV=py27-virtualenv-18x
+  - TOX_ENV=py27-virtualenv-19x
+  - TOX_ENV=py27-virtualenv-150x
+  - TOX_ENV=py27-virtualenv-151x
+script: tox -e $TOX_ENV
 notifications:
   email:
     - kyle.gibson@frozenonline.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: python
-install: pip install tox
-env:
-  - TOX_ENV=docs
-  - TOX_ENV=pep8
-  - TOX_ENV=py26-15.0.3
-  - TOX_ENV=py26-15.1.0
-  - TOX_ENV=py27-15.0.3
-  - TOX_ENV=py27-15.1.0
-script: tox -e $TOX_ENV
+install: pip install tox-travis
+script: tox
 notifications:
   email:
     - kyle.gibson@frozenonline.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ install: pip install tox
 env:
   - TOX_ENV=docs
   - TOX_ENV=pep8
-  - TOX_ENV=py26-venv-1.7.2
-  - TOX_ENV=py26-venv-1.8.4
-  - TOX_ENV=py26-venv-1.9.1
-  - TOX_ENV=py27-venv-1.7.2
-  - TOX_ENV=py27-venv-1.8.4
-  - TOX_ENV=py27-venv-1.9.1
+  - TOX_ENV=py26-14.0.6
+  - TOX_ENV=py26-15.0.3
+  - TOX_ENV=py26-15.1.0
+  - TOX_ENV=py27-14.0.6
+  - TOX_ENV=py27-15.0.3
+  - TOX_ENV=py27-15.1.0
 script: tox -e $TOX_ENV
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+install: pip install tox
 env:
   - TOX_ENV=docs
   - TOX_ENV=py27-flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ install: pip install tox
 env:
   - TOX_ENV=docs
   - TOX_ENV=pep8
-  - TOX_ENV=py26-14.0.5
   - TOX_ENV=py26-15.0.3
   - TOX_ENV=py26-15.1.0
-  - TOX_ENV=py27-14.0.5
   - TOX_ENV=py27-15.0.3
   - TOX_ENV=py27-15.1.0
 script: tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ install: pip install tox
 env:
   - TOX_ENV=docs
   - TOX_ENV=pep8
-  - TOX_ENV=py26-14.0.6
+  - TOX_ENV=py26-14.0.5
   - TOX_ENV=py26-15.0.3
   - TOX_ENV=py26-15.1.0
-  - TOX_ENV=py27-14.0.6
+  - TOX_ENV=py27-14.0.5
   - TOX_ENV=py27-15.0.3
   - TOX_ENV=py27-15.1.0
 script: tox -e $TOX_ENV

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -88,7 +88,10 @@ Setting up tox
 Running tox
 -----------
 
-Now that you have ``tox`` setup, you just need to run the command ``tox`` from the project root directory.
+Now that you have ``tox`` setup,
+you just need to run
+the command ``tox``
+from the project root directory.
 
 .. code-block:: shell-session
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -103,7 +103,7 @@ The terrarium project welcomes help in any of the following ways:
   tests and documentation.
 * Participating on open issues and pull requests,
   reviewing changes
-  
+
 Pull Request Checklist
 ======================
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,10 +2,20 @@
 Installation
 ############
 
-Python & OS Support
-###################
+Requirements
+############
 
-terrarium is supported and tested with CPython versions 2.6 and 2.7.
+* CPython 2.7 or 2.6
+* `virtualenv <https://virtualenv.pypa.io/en/stable/>`_
+  (only the latest 3 versions are officially supported and tested)
+  15.1.x, 15.0.x, 14.0.x
+
+.. note::
+
+    As Python 2.6 is no longer being maintained,
+    terrarium's support for 2.6
+    is officially deprecated
+    and will be removed in a future version.
 
 Install using pip
 #################

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,8 +7,8 @@ Requirements
 
 * CPython 2.7 or 2.6
 * `virtualenv <https://virtualenv.pypa.io/en/stable/>`_
-  (only the latest 3 versions are officially supported and tested)
-  15.1.x, 15.0.x, 14.0.x
+  (only the latest 2 versions are officially supported and tested)
+  15.1.x, 15.0.x
 
 .. note::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,8 +7,6 @@ Python & OS Support
 
 terrarium is supported and tested with CPython versions 2.6 and 2.7.
 
-terrarium is supported and tested with Linux and Windows.
-
 Install using pip
 #################
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def find_version(*file_paths):
 def main():
     python_version = sys.version_info[:2]
     install_requires = [
-        'virtualenv>=1.7.2,<=1.9.1',
+        'virtualenv',
     ]
     if python_version < (2, 7) or (3, 0) <= python_version <= (3, 1):
         install_requires += ['argparse']

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, pep8, py26-venv-1.7.2, py26-venv-1.8.4, py26-venv-1.9.1, py27-venv-1.7.2, py27-venv-1.8.4, py27-venv-1.9.1
+envlist = docs, pep8, py27-14.0.6, py27-15.0.3, py27-15.1.0, py26-14.0.6, py26-15.0.3, py26-15.1.0
 
 [testenv]
 commands =
@@ -18,42 +18,6 @@ commands =
 deps = -rrequirements/docs.txt
 skipsdist = True
 
-[testenv:py26-venv-1.7.2]
-basepython = python2.6
-deps =
-    virtualenv==1.7.2
-    -rrequirements/testing.txt
-
-[testenv:py26-venv-1.8.4]
-basepython = python2.6
-deps =
-    virtualenv==1.8.4
-    -rrequirements/testing.txt
-
-[testenv:py26-venv-1.9.1]
-basepython = python2.6
-deps =
-    virtualenv==1.9.1
-    -rrequirements/testing.txt
-
-[testenv:py27-venv-1.7.2]
-basepython = python2.7
-deps =
-    virtualenv==1.7.2
-    -rrequirements/testing.txt
-
-[testenv:py27-venv-1.8.4]
-basepython = python2.7
-deps =
-    virtualenv==1.8.4
-    -rrequirements/testing.txt
-
-[testenv:py27-venv-1.9.1]
-basepython = python2.7
-deps =
-    virtualenv==1.9.1
-    -rrequirements/testing.txt
-
 [testenv:pep8]
 basepython = python2.7
 deps = flake8
@@ -62,3 +26,41 @@ commands = flake8 .
 [flake8]
 exclude = .tox,*.egg,build,_vendor,data,docs
 select = E,W,F
+
+####### Python 2.6
+[testenv:py26-14.0.6]
+basepython = python2.6
+deps =
+    virtualenv==14.0.6
+    -rrequirements/testing.txt
+
+[testenv:py26-15.0.3]
+basepython = python2.6
+deps =
+    virtualenv==15.0.3
+    -rrequirements/testing.txt
+
+[testenv:py26-15.1.0]
+basepython = python2.6
+deps =
+    virtualenv==15.1.0
+    -rrequirements/testing.txt
+
+####### Python 2.7
+[testenv:py27-14.0.6]
+basepython = python2.7
+deps =
+    virtualenv==14.0.6
+    -rrequirements/testing.txt
+
+[testenv:py27-15.0.3]
+basepython = python2.7
+deps =
+    virtualenv==15.0.3
+    -rrequirements/testing.txt
+
+[testenv:py27-15.1.0]
+basepython = python2.7
+deps =
+    virtualenv==15.1.0
+    -rrequirements/testing.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, py27-pep8, py{26,27}-{15.0.3,15.1.0}
+envlist = docs, py27-pep8, py{26,27}-virtualenv-{150x,151x}
 
 [testenv]
 commands =
   virtualenv --version
   python -V
   nosetests {posargs:-v}
+deps =
+  -rrequirements/testing.txt
+  virtualenv-150x: virtualenv==15.0.3
+  virtualenv-151x: virtualenv==15.1.0
 
 [testenv:docs]
 commands =
@@ -25,25 +29,3 @@ commands = flake8 .
 [flake8]
 exclude = .tox,*.egg,build,_vendor,data,docs
 select = E,W,F
-
-####### Python 2.6
-[testenv:py26-15.0.3]
-deps =
-    virtualenv==15.0.3
-    -rrequirements/testing.txt
-
-[testenv:py26-15.1.0]
-deps =
-    virtualenv==15.1.0
-    -rrequirements/testing.txt
-
-####### Python 2.7
-[testenv:py27-15.0.3]
-deps =
-    virtualenv==15.0.3
-    -rrequirements/testing.txt
-
-[testenv:py27-15.1.0]
-deps =
-    virtualenv==15.1.0
-    -rrequirements/testing.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, py27-pep8, py{26,27}-virtualenv-{150x,151x}
+envlist = docs, py27-flake8, py{26,27}-virtualenv-{150x,151x}
 
 [testenv]
 commands =
@@ -22,7 +22,7 @@ commands =
 deps = -rrequirements/docs.txt
 skipsdist = True
 
-[testenv:py27-pep8]
+[testenv:py27-flake8]
 deps = flake8
 commands = flake8 .
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, py27-flake8, py{26,27}-virtualenv-{150x,151x}
+envlist = docs, py27-flake8, py{26,27}-virtualenv-{150x,151x,19x,18x,17x}
 
 [testenv]
 commands =
@@ -13,6 +13,9 @@ commands =
   nosetests {posargs:-v}
 deps =
   -rrequirements/testing.txt
+  virtualenv-17x: virtualenv==1.7.2
+  virtualenv-18x: virtualenv==1.8.4
+  virtualenv-19x: virtualenv==1.9.1
   virtualenv-150x: virtualenv==15.0.3
   virtualenv-151x: virtualenv==15.1.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, pep8, py{26,27}-{15.0.3,15.1.0}
+envlist = docs, py27-pep8, py{26,27}-{15.0.3,15.1.0}
 
 [testenv]
 commands =
@@ -18,8 +18,7 @@ commands =
 deps = -rrequirements/docs.txt
 skipsdist = True
 
-[testenv:pep8]
-basepython = python2.7
+[testenv:py27-pep8]
 deps = flake8
 commands = flake8 .
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, pep8, py27-15.0.3, py27-15.1.0, py26-15.0.3, py26-15.1.0
+envlist = docs, pep8, py{26,27}-{15.0.3,15.1.0}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -29,26 +29,22 @@ select = E,W,F
 
 ####### Python 2.6
 [testenv:py26-15.0.3]
-basepython = python2.6
 deps =
     virtualenv==15.0.3
     -rrequirements/testing.txt
 
 [testenv:py26-15.1.0]
-basepython = python2.6
 deps =
     virtualenv==15.1.0
     -rrequirements/testing.txt
 
 ####### Python 2.7
 [testenv:py27-15.0.3]
-basepython = python2.7
 deps =
     virtualenv==15.0.3
     -rrequirements/testing.txt
 
 [testenv:py27-15.1.0]
-basepython = python2.7
 deps =
     virtualenv==15.1.0
     -rrequirements/testing.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, pep8, py27-14.0.6, py27-15.0.3, py27-15.1.0, py26-14.0.6, py26-15.0.3, py26-15.1.0
+envlist = docs, pep8, py27-14.0.5, py27-15.0.3, py27-15.1.0, py26-14.0.5, py26-15.0.3, py26-15.1.0
 
 [testenv]
 commands =
@@ -28,10 +28,10 @@ exclude = .tox,*.egg,build,_vendor,data,docs
 select = E,W,F
 
 ####### Python 2.6
-[testenv:py26-14.0.6]
+[testenv:py26-14.0.5]
 basepython = python2.6
 deps =
-    virtualenv==14.0.6
+    virtualenv==14.0.5
     -rrequirements/testing.txt
 
 [testenv:py26-15.0.3]
@@ -47,10 +47,10 @@ deps =
     -rrequirements/testing.txt
 
 ####### Python 2.7
-[testenv:py27-14.0.6]
+[testenv:py27-14.0.5]
 basepython = python2.7
 deps =
-    virtualenv==14.0.6
+    virtualenv==14.0.5
     -rrequirements/testing.txt
 
 [testenv:py27-15.0.3]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, pep8, py27-14.0.5, py27-15.0.3, py27-15.1.0, py26-14.0.5, py26-15.0.3, py26-15.1.0
+envlist = docs, pep8, py27-15.0.3, py27-15.1.0, py26-15.0.3, py26-15.1.0
 
 [testenv]
 commands =
@@ -28,12 +28,6 @@ exclude = .tox,*.egg,build,_vendor,data,docs
 select = E,W,F
 
 ####### Python 2.6
-[testenv:py26-14.0.5]
-basepython = python2.6
-deps =
-    virtualenv==14.0.5
-    -rrequirements/testing.txt
-
 [testenv:py26-15.0.3]
 basepython = python2.6
 deps =
@@ -47,12 +41,6 @@ deps =
     -rrequirements/testing.txt
 
 ####### Python 2.7
-[testenv:py27-14.0.5]
-basepython = python2.7
-deps =
-    virtualenv==14.0.5
-    -rrequirements/testing.txt
-
 [testenv:py27-15.0.3]
 basepython = python2.7
 deps =


### PR DESCRIPTION
Update tox to only test against 15.0.3, and 15.1.0. We would support 14.x too, but it seems busted. 

Drop explicit support for all prior versions, though they will likely continue to work in this version.

I'm not sure what version we will want to bump terrarium after this. Technically this release won't break anything for existing users, yet it will allow users to use an upgraded virtualenv if they choose. For that reason, 1.0.1 makes sense. However, maybe it should be 1.1.0, or even 2.0.0?