### PR TITLE
Copy archive first to tempfile in same directory

### DIFF
--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -511,7 +511,6 @@ class Terrarium(object):
             os.rename(temp, dest)
             logger.info('Archive copied to storage directory')
             os.unlink(archive)
-            os.unlink(temp)
 
     def upload_to_s3(self, target):
         logger.info('Uploading environment to S3')

--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -506,9 +506,12 @@ class Terrarium(object):
             archive = self.archive(target)
             if not archive:
                 logger.error('Archiving failed')
-            shutil.copyfile(archive, dest)
+            _, temp = tempfile.mkstemp(dir=storage_dir)
+            shutil.copyfile(archive, temp)
+            os.rename(temp, dest)
             logger.info('Archive copied to storage directory')
             os.unlink(archive)
+            os.unlink(temp)
 
     def upload_to_s3(self, target):
         logger.info('Uploading environment to S3')


### PR DESCRIPTION
Leaving a partially-copied archive with the relevant name in the storage dir creates a problem since there is an archive present, so no new virtualenv is built, but it can't be used. We should first write to a temporary file in the same directory, then do `os.rename()` which is guaranteed to be atomic.