### PR TITLE
Support Python 3 in virtual envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: python
 install: pip install tox
-env:
-  - TOX_ENV=docs
-  - TOX_ENV=py27-flake8
-  - TOX_ENV=py27-virtualenv-150x
-  - TOX_ENV=py27-virtualenv-151x
-  - TOX_ENV=py27-virtualenv-152x
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=docs
+    - python: 2.7
+      env: TOX_ENV=py27-flake8
+    - python: 2.7
+      env: TOX_ENV=py27-virtualenv-150x
+    - python: 2.7
+      env: TOX_ENV=py27-virtualenv-151x
+    - python: 3.6
+      env: TOX_ENV=py27-virtualenv-150x
+    - python: 3.6
+      env: TOX_ENV=py27-virtualenv-151x
 script: tox -e $TOX_ENV
 notifications:
   email:

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -66,6 +66,15 @@ The following options are only available if ``gcloud`` is installed.
     e.g. ``S3_BUCKET``, ``GCS_BUCKET``
     instead of being passed in as a parameter.
 
+Using Python 3 inside virtualenv
+================================
+
+Use ``-p`` argument to choose Python executable installed in virtualenv:
+
+.. code-block:: shell-session
+
+    $ terrarium -p python3.6 --target env --storage-dir path/to/environments install requirements.txt
+
 Tips
 ####
 

--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -510,11 +510,12 @@ class Terrarium(object):
 
     def get_version_tuple_from_executable(self, executable):
         cmd = [executable, '--version']
-        pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        # py3 prints to stdout, py2 to stderr
+        pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         out, _ = pipe.communicate()
         if pipe.returncode != 0:
-            raise OSError('Command {0} failed with error code {1}'
-                          .format(cmd, pipe.returncode))
+            raise OSError('Command {0} failed with error code {1}, output: {2}'
+                          .format(cmd, pipe.returncode, out))
         # out: Python 3.6.3
         version = out.strip().split()[1]
         return version.split('.')

--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -309,6 +309,8 @@ class Terrarium(object):
         for name in os.listdir(location):
             full_path = os.path.join(location, name)
             data = None
+            if not os.path.isfile(full_path):
+                continue
             with open(full_path) as f:
                 header = f.read(len(MAGIC_NUM['ELF']))
                 # Skip binary files

--- a/terrarium/terrarium.py
+++ b/terrarium/terrarium.py
@@ -511,7 +511,8 @@ class Terrarium(object):
     def get_version_tuple_from_executable(self, executable):
         cmd = [executable, '--version']
         # py3 prints to stdout, py2 to stderr
-        pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        pipe = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         out, _ = pipe.communicate()
         if pipe.returncode != 0:
             raise OSError('Command {0} failed with error code {1}, output: {2}'


### PR DESCRIPTION
It's not porting terraform itself to Python 3. Terraform still runs with Python 2.7, but now supports `-p` flag to set Python version inside virtualenv. This simple change should be enough for people who need Python 3 support.